### PR TITLE
Fix line intersects

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Geospatial Consortium's recommendation!
 ```javascript
 gju.lineStringsIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
                  { "type": "LineString", "coordinates": [[3, 0], [3, 4], [4,4], [4,0]] })
-// [{"type":"Point","coordinates":[2,3]},{"type":"Point","coordinates":[2,4]}]
+// [{"type":"Point","coordinates":[3,2]},{"type":"Point","coordinates":[4,2]}]
 
 gju.lineStringsIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
                  { "type": "LineString", "coordinates": [[0, 0], [5, 0]] })

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Geospatial Consortium's recommendation!
 ## Line intersections
 
 ```javascript
-gju.linesIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
+gju.lineStringsIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
                  { "type": "LineString", "coordinates": [[3, 0], [3, 4], [4,4], [4,0]] })
 // [{"type":"Point","coordinates":[2,3]},{"type":"Point","coordinates":[2,4]}]
 
-gju.linesIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
+gju.lineStringsIntersect({ "type": "LineString", "coordinates": [[0, 2], [5, 2]] },
                  { "type": "LineString", "coordinates": [[0, 0], [5, 0]] })
 // false
 ```

--- a/geojson-utils.js
+++ b/geojson-utils.js
@@ -12,20 +12,20 @@
     for (var i = 0; i <= l1.coordinates.length - 2; ++i) {
       for (var j = 0; j <= l2.coordinates.length - 2; ++j) {
         var a1 = {
-          x: l1.coordinates[i][1],
-          y: l1.coordinates[i][0]
+          x: l1.coordinates[i][0],
+          y: l1.coordinates[i][1]
         },
           a2 = {
-            x: l1.coordinates[i + 1][1],
-            y: l1.coordinates[i + 1][0]
+            x: l1.coordinates[i + 1][0],
+            y: l1.coordinates[i + 1][1]
           },
           b1 = {
-            x: l2.coordinates[j][1],
-            y: l2.coordinates[j][0]
+            x: l2.coordinates[j][0],
+            y: l2.coordinates[j][1]
           },
           b2 = {
-            x: l2.coordinates[j + 1][1],
-            y: l2.coordinates[j + 1][0]
+            x: l2.coordinates[j + 1][0],
+            y: l2.coordinates[j + 1][1]
           },
           ua_t = (b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x),
           ub_t = (a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x),


### PR DESCRIPTION
`lineStringsIntersect` was flipping X/Y coordinates during calculation.

additionally, the documentation listed the method name as `linesIntersect`, not `lineStringsIntersect`
