### PR TITLE
Remove reference to old README.textile

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,5 @@
     "geocouch"
   ],
   "author": "Max Ogden",
-  "license": "MIT",
-  "readmeFilename": "README.textile"
+  "license": "MIT"
 }


### PR DESCRIPTION
Hi, Max! Long time no see!

I was browsing around this package and noticed an odd package.json reference I had never seen before, `readmeFilename`. Anyway, I think it references an old README file which you no longer use. This PR gets rid of it. Cheers!
