### PR TITLE
Make library usable with strict mode

### DIFF
--- a/geojson-utils.js
+++ b/geojson-utils.js
@@ -1,5 +1,5 @@
 (function () {
-  var gju = this.gju = {};
+  var gju = {};
 
   // Export the geojson object for **CommonJS**
   if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
"this" is undefined in strict mode (--use_strict), so a require() fails. Also this doesn't seem to be used anywhere in the script.
